### PR TITLE
error caused when parsing your log line "console.log document"

### DIFF
--- a/lib/nowpad.coffee
+++ b/lib/nowpad.coffee
@@ -25,7 +25,7 @@ class Client
 		# Apply
 		@id = id
 		@nowpad = nowpad
-	
+
 	# Destroy
 	destroy: ->
 		# Prepare
@@ -45,7 +45,7 @@ class Client
 				delete document.clientIds[clientId]
 				if document.clientIds.length is 0
 					document.destroy()
-	
+
 		# Log
 		console.log 'Destroyed Client', clientId
 
@@ -85,9 +85,9 @@ class Document
 		else
 			console.log 'Client '+clientId+' failed to lock the document '+@id
 			console.log 'it\'s currently locked by client '+@locked
-		
+
 		return success
-	
+
 	# Unlock
 	unlock: (clientId) ->
 		success = false
@@ -99,9 +99,9 @@ class Document
 		else
 			console.log 'Client '+clientId+' failed to unlock the document '+@id
 			console.log 'it\'s currently locked by client '+@locked
-		
+
 		return success
-	
+
 	# Destroy
 	destroy: ->
 		# Prepare
@@ -121,7 +121,7 @@ class Document
 				delete document.documentIds[documentId]
 				if client.documentIds.length is 0
 					client.destroy()
-		
+
 		# Log
 		console.log 'Destroyed Document', documentId
 
@@ -129,7 +129,7 @@ class DocumentList extends List
 	# Init
 	constructor: (nowpad) ->
 		@nowpad = nowpad
-	
+
 	# Get a document, or create it if it doesn't exist
 	# next(err,document)
 	fetch: (id,next) ->
@@ -169,12 +169,12 @@ class Nowpad
 	documents: null
 	clients: null
 	requestHandler: null
-	
+
 	# Events
 	events:
 		sync: []
 		disconnected: []
-	
+
 	# Initialise
 	constructor: ({server,everyone}={}) ->
 		# Prepare
@@ -210,20 +210,20 @@ class Nowpad
 					@fileString += coffee.compile(data.toString())
 				else
 					@fileString += data.toString()
-	
+
 	# Server the client script
 	serveClientScript: (req,res) ->
 		res.writeHead 200, 'content-type': 'text/javascript'
 		res.write @fileString
 		res.end()
-	
+
 	# Log
 	log: ->
 		console.log(
 			clients: @clients
 			documents: @documents
 		)
-	
+
 	# Add document
 	addDocument: (documentId,value) ->
 		unless @documents.has documentId
@@ -241,7 +241,7 @@ class Nowpad
 		if @requestHandler
 			throw new Error 'Request handler already defined'
 		@requestHandler = requestHandler
-	
+
 	# Initialise Now.js
 	nowBind: ->
 		nowpad = @
@@ -268,21 +268,21 @@ class Nowpad
 
 			# Log
 			console.log 'Bye Client:', clientId
-		
+
 		# A client is shaking hands with the server
 		everyone.now.nowpad_handshake = (notifySync,notifyDelay,callback) ->
 			# Check the user isn't evil
 			if (typeof notifySync isnt 'function') or (typeof notifyDelay isnt 'function')
 				console.log 'Evil client'
 				return false
-			
+
 			# Apply the client-side functions used to notify the client to the now session
 			@now.nowpad_notifySync = notifySync
 			@now.nowpad_notifyDelay = notifyDelay
 
 			# Trigger the callback
 			if callback then callback(@now.clientId)
-	
+
 		# Create a timer to ensure locks don't last forever
 		lockTimer = false
 		lockTimerDelay = 1500
@@ -307,10 +307,10 @@ class Nowpad
 						console.log '\n!!! A lock has lasted too long... !!!\n'
 						document.unlock @now.clientId
 					lockTimer = setTimeout lockTimerCallback, lockTimerDelay
-				
+
 				# Send result back to client
 				if callback then callback result
-			
+
 		# Unlock
 		everyone.now.nowpad_unlockDocument = (documentId, callback) ->
 			# Fetch Document
@@ -329,11 +329,11 @@ class Nowpad
 
 				# Send result back to client
 				if callback then callback result
-			
+
 		# Log
 		everyone.now.nowpad_log = ->
 			nowpad.log()
-		
+
 		# A document is preparing for sync
 		everyone.now.nowpad_valueSyncDocument = (documentId, callback) ->
 			# Fetch document
@@ -342,7 +342,7 @@ class Nowpad
 				if err
 					console.log err
 					return
-				
+
 				# Fetch values
 				state = document.state
 				value = document.value
@@ -353,7 +353,7 @@ class Nowpad
 
 				# Log
 				console.log 'Valuing', @now.clientId, 'for document', documentId
-			
+
 		# Sync
 		everyone.now.nowpad_patchSyncDocument = (documentId,clientState,patch,callback) ->
 			# Fetch document
@@ -362,14 +362,13 @@ class Nowpad
 				if err
 					console.log err
 					return
-				
+
 				# Prepare
 				stateQueue = []
 				document.state = document.state || 0
 
 				# Log
 				console.log '\nSyncing ['+@now.clientId+'/'+documentId+']'
-				console.log document
 				console.log ''
 
 				# Update Client
@@ -378,7 +377,7 @@ class Nowpad
 
 					# Add patches
 					stateQueue = document.states.slice clientState
-					
+
 					# Log
 					console.log 'Syncing from', clientState, 'to', document.state
 					console.log stateQueue
@@ -399,7 +398,7 @@ class Nowpad
 						id: document.state
 						patch: patch
 						clientId: @now.clientId
-					
+
 					# Add
 					stateQueue.push State
 					document.states.push State
@@ -410,7 +409,7 @@ class Nowpad
 
 				# Return updates to client
 				callback(stateQueue,document.state)
-				
+
 				# Notify other clients
 				if patch
 					# Notify nowpad clients
@@ -418,14 +417,14 @@ class Nowpad
 
 					# Notify application
 					nowpad.trigger 'sync', [document.id, document.value, document.state]
-		
+
 	# Bind
 	bind: (event,callback) ->
 		if typeof @events[event] is 'undefined'
 			throw new Error 'Unauthorised event: '+event
 		else
 			@events[event].push callback
-	
+
 	# Trigger
 	trigger: (event,args) ->
 		@events[event].forEach (callback) ->


### PR DESCRIPTION
I was using nowpad as a library for your filepad project.

I removed 'console.log document' as I was getting errors when the interpreter try to get a string from the 'document' variable

See below for the error message when this crashes:
Cannot convert object to primitive value
TypeError: Cannot convert object to primitive value
    at String.STRING_ADD_LEFT (native)
    at isRegExp (util.js:287:14)
    at format (util.js:184:11)
    at util.js:216:19
    at Array.map (native)
    at format (util.js:193:23)
    at util.js:216:19
    at Array.map (native)
    at format (util.js:193:23)
    at util.js:216:19
